### PR TITLE
Enable keep-alive on proxy backend connections.

### DIFF
--- a/lib/use-mcp-server-proxy.js
+++ b/lib/use-mcp-server-proxy.js
@@ -4,7 +4,7 @@ import https from 'node:https';
 import { refreshIdentityToken } from './identity-client.js';
 import { getSessionResetUrl, destroyAccess } from "./use-session-reset.js";
 
-const proxyAgent = new http.Agent({ keepAlive: false });
+const proxyAgent = new http.Agent({ keepAlive: true });
 const proxyOptions = { agent: proxyAgent };
 
 // Proxy through the MCP Resource Server route: guards to ensure authorized, and if not MCP Client attempts OAuth flow.


### PR DESCRIPTION
Based on [agreement in Slack #heroku-remote-mcp-server](https://salesforce-internal.slack.com/archives/C08PQ3VQX4J/p1750268047739299), we should enable keep-alive to avoid performance penalties of recreating TCP connections for every proxied request.