### PR TITLE
fixes buildpack compile to copy .mjs files

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ set -e
 mkdir -p "$INSTALL_DIR"
 
 # Only add the required files & directories to the slug
-cp -r lib patches *.js *.json "$INSTALL_DIR"
+cp -r lib patches *.mjs *.js *.json "$INSTALL_DIR"
 
 cd "$INSTALL_DIR"
 npm install --omit dev


### PR DESCRIPTION
# Context

This buildpack relies upon the presence of `my-loader.mjs` in the root of the buildpack. As such, the `bin/compile` script has been updated to copy .mjs files.

# Risk

Low

[GUS Ticket](https://gus.lightning.force.com/lightning/r/a07EE00002FuXr7YAF/view)