### PR TITLE
Destroying the session seems to cause a not found during the flow whe…

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -191,12 +191,6 @@ function server(env = {}, listeningCallback, exitFunc) {
         null, 
         providerInstanceConfig.cookies.long
       );
-      // Session must surely be present, but just in case, only destroy 
-      // it if present.
-      const sessionEntity = ctx.oidc?.entities?.Session;
-      if (sessionEntity) {
-        await sessionEntity.destroy();
-      }
     }
   });
 


### PR DESCRIPTION
…n deployed. The 404 is being caused because the session object was deleted from Redis.