### PR TITLE
Reject Unauthorized TLS connections for Redis

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -48,7 +48,11 @@ function server(env = {}, listeningCallback, exitFunc) {
         keyPrefix: 'rate-limit:',
         retryDelayOnFailover: 100,
         maxRetriesPerRequest: 3,
-        lazyConnect: true
+        lazyConnect: true,
+        tls: {
+          // Accept self-signed certificates
+          rejectUnauthorized: false
+        }
       });
 
       rateLimitRedisClient.on('error', (err) => {


### PR DESCRIPTION
Need to add into option to the Redis config for the simple client used to store rate limiting counts