### PR TITLE
Browser test using custom mcp-remote version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm install
         env:
           NPM_TOKEN: ${{ secrets.NODE_TOKEN }}
+      - run: npm ci
       - run: npm test


### PR DESCRIPTION
**Description**

This PR was originally opened by @mars to introduce a custom `mcp-remote-client` for testing the MCP Auth Proxy in CI. However, there was an issue with a Node package that is only available via the Heroku private npm account.

The additional changes from @heroku-johnny address the issue with accessing the private package. Specifically, a `NODE_TOKEN` environment secret was added to the GitHub repository so it can be securely used in the GitHub Actions workflow. An environment named `"ci"` was also added to the repository for use during CI testing.

**Why We Used Environment Secrets Instead of Repository Secrets**

We chose to use environment secrets rather than repository secrets for the following reasons:

**Environment Secrets (More Secure):**
- Only accessible to workflows targeting the specific environment
- Can be protected with approval requirements and other rules
- Limits the blast radius if a secret is compromised

**Repository Secrets (Less Secure but Easier):**
- Accessible to all workflows in the repository
- No additional environment setup required
- Compatible with existing workflow configurations

Although repository secrets would have been easier to use, environment secrets provide stronger security and better scoping, which we felt was important for handling private credentials.

**Work item**
[W-18902154](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002Gy4JtYAJ/view)