### PR TITLE
chore: add rate limiting to all routes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -68,8 +68,13 @@ function server(env = {}, listeningCallback, exitFunc) {
   const app = express();
   app.use(express.json());
   
-  // Create rate limiting middleware (but don't apply globally yet)
+  // Create rate limiting middleware
   const rateLimitMiddleware = createRateLimitMiddleware(env);
+
+  // Apply rate limiting globally to all routes
+  if (rateLimitMiddleware) {
+    app.use(rateLimitMiddleware);
+  }
 
   let oidcViewsPath;
   if (OIDC_PROVIDER_VIEWS_PATH) {
@@ -157,8 +162,7 @@ function server(env = {}, listeningCallback, exitFunc) {
 
   // Declare the Authorization Server Metadata for the proxied MCP Server, at /mcp
   // https://datatracker.ietf.org/doc/html/rfc8414
-  const middlewares = rateLimitMiddleware ? [rateLimitMiddleware] : [];
-  app.get('/.well-known/oauth-authorization-server', ...middlewares, async (_req, res) => {
+  app.get('/.well-known/oauth-authorization-server', async (_req, res) => {
     res.json({
       "issuer":
         `${BASE_URL}`,


### PR DESCRIPTION
# Description

[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002J6T9IYAV/view)

This PR refactors the rate limiting logic to cover all routes by using `app.use()` instead of adding the rate limiting middleware on a route's [route handler](https://github.com/heroku/mcp-remote-auth-proxy/blob/a1781e765d3481538f8eaa84f104764ee11f9d98/lib/server.js#L161). The routes covered include:
- OAuth/OIDC endpoints
- Interaction routes
- Any future routes

# Testing
All tests passing

