### PR TITLE
fix: keep client when resetting session

### DIFF
--- a/lib/use-session-reset.js
+++ b/lib/use-session-reset.js
@@ -8,7 +8,6 @@ let authServerBaseUrl; // Store for building OAuth recovery URLs
 
 // Call this before redirecting into sessionResetUrl
 export async function destroyAccess(provider, accessToken) {
-  await provider.Client.adapter.destroy(accessToken.clientId);
   await provider.Grant.adapter.destroy(accessToken.grantId);
   await provider.AccessToken.adapter.destroy(accessToken.jti);
 


### PR DESCRIPTION
# Description

[GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002J6aS8YAJ/view)

As part of testing the resolution for the [OAuth lifecycle issue](https://github.com/heroku/mcp-remote-auth-proxy/pull/37) using Cursor, it was discovered that the mcp-auth-proxy server was removing the `clientId` during the session resetting. This would result in an infinite session reset returning `{"error": "invalid_client", "error_description": "Session reset"}`. This update should remedy this issue.

NOTE: Additional manual testing for this function will be conducted after merging.