### PR TITLE
fix: adds new policy prompt to allow prompt=consent

### DIFF
--- a/lib/interaction-policy.js
+++ b/lib/interaction-policy.js
@@ -2,9 +2,20 @@ import { interactionPolicy } from 'oidc-provider';
 
 const policy = interactionPolicy.base();
 
-// Do not show consent for this oauth proxy flow, since primary Identity already asks consent.
-// https://github.com/panva/node-oidc-provider/blob/main/docs/README.md#interactionspolicy
+// Accept prompt=consent (RFC 6749 / OIDC Core) without rendering a consent UI.
+// Primary Identity collects consent upstream; the proxy resolves the consent
+// prompt in the identity callback by calling interactionFinished with
+// { consent: { grantId } } (see use-interaction-routes-adapter.js).
 policy.remove('consent');
+policy.add(new interactionPolicy.Prompt(
+  { name: 'consent', requestable: true },
+  new interactionPolicy.Check(
+    'consent_granted_upstream',
+    'consent is collected by primary Identity',
+    'consent_required',
+    () => interactionPolicy.Check.NO_NEED_TO_PROMPT
+  )
+));
 
 let confirmLoginPrompt = new interactionPolicy.Prompt(
   { name: 'confirm-login', requestable: true },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-remote-auth-proxy",
-  "version": "1.1.0",
+  "version": "1.3.0",
   "description": "OIDC OAuth provider for remote MCP servers",
   "type": "module",
   "packageManager": "pnpm@10.30.3",

--- a/test/authorize-prompt-consent-test.js
+++ b/test/authorize-prompt-consent-test.js
@@ -1,0 +1,131 @@
+// Integration test for the prompt=consent fix.
+//
+// Background: Claude Desktop's MCP Custom Connector flow appends `prompt=consent`
+// to the OAuth authorization request. Before the fix, oidc-provider rejected the
+// request with `invalid_request` ("unsupported prompt value requested") because
+// `policy.remove('consent')` had stripped the consent prompt from the supported
+// set (see configuration.js#collectPrompts). The fix re-registers a no-op
+// consent prompt so `prompt=consent` is accepted while still skipping any
+// consent UI (Heroku Identity collects consent upstream).
+//
+// This test exercises the real `/auth` endpoint via `provider.callback()` to
+// verify the spec-compatibility regression cannot reappear.
+
+import assert from 'node:assert';
+import http from 'node:http';
+import { URLSearchParams } from 'node:url';
+import express from 'express';
+import { Provider } from 'oidc-provider';
+
+import providerConfig from '../lib/provider-config.js';
+import { clientData } from './mocks/authorized-client-data.js';
+
+describe('GET /auth with prompt parameter', function () {
+  const env = process.env;
+  const authProxyUrl = new URL(env.BASE_URL);
+
+  let server;
+  let provider;
+
+  beforeEach(async function () {
+    // Use the real provider config but drop the Redis-backed adapter so the
+    // test runs on the in-memory adapter — same pattern as
+    // mcp-server-proxy-test.js.
+    const { adapter: _ignored, ...testProviderConfig } = providerConfig;
+    provider = new Provider(authProxyUrl.href, testProviderConfig);
+
+    // Seed a native PKCE client so /auth has a valid client_id to bind to.
+    // identityLoginConfirmed=true (set in the fixture) lets the confirm-login
+    // prompt resolve immediately, so the only interactions left to drive the
+    // redirect are `login` (and, when requested, `consent`).
+    await provider.Client.adapter.upsert(clientData.client_id, clientData);
+
+    const app = express();
+    app.use(provider.callback());
+
+    await new Promise((resolve) => {
+      server = app.listen(authProxyUrl.port, resolve);
+    });
+  });
+
+  afterEach(function (done) {
+    server.close((err) => (err ? done(err) : done()));
+  });
+
+  // PKCE values are arbitrary; the authorize endpoint only validates the
+  // shape, not the verifier — there's no /token call in this test.
+  const codeChallenge = 'vhFpUu8KpfoFrxhlKCW8HdD06ZAdosgFgRpg6GlhqWY';
+
+  function buildAuthorizePath(extraParams = {}) {
+    const params = new URLSearchParams({
+      client_id: clientData.client_id,
+      redirect_uri: clientData.redirect_uris[0],
+      response_type: 'code',
+      scope: 'openid offline_access',
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+      state: 'test-state',
+      ...extraParams,
+    });
+    return `/auth?${params.toString()}`;
+  }
+
+  function get(path) {
+    return new Promise((resolve, reject) => {
+      const req = http.request(
+        {
+          protocol: authProxyUrl.protocol,
+          hostname: authProxyUrl.hostname,
+          port: authProxyUrl.port,
+          path,
+          method: 'GET',
+        },
+        (res) => {
+          let body = '';
+          res.on('data', (chunk) => (body += chunk));
+          res.on('end', () => resolve({ statusCode: res.statusCode, headers: res.headers, body }));
+        }
+      );
+      req.on('error', reject);
+      req.end();
+    });
+  }
+
+  it('redirects to /interaction/:uid when prompt=consent is requested', async function () {
+    const res = await get(buildAuthorizePath({ prompt: 'consent' }));
+
+    // Regression guard: before the fix this was a redirect back to the client
+    // (clientData.redirect_uris[0]) with `error=invalid_request` and
+    // `error_description=unsupported%20prompt%20value%20requested`.
+    assert.equal(res.statusCode, 303, 'should redirect to interaction, not error');
+    assert(res.headers.location, 'response must include a Location header');
+    assert(
+      res.headers.location.startsWith('/interaction/'),
+      `expected redirect to /interaction/:uid, got ${res.headers.location}`
+    );
+    assert(
+      !res.headers.location.includes('error=invalid_request'),
+      'response must not redirect back to the client with error=invalid_request'
+    );
+  });
+
+  it('redirects to /interaction/:uid with no prompt parameter (control)', async function () {
+    const res = await get(buildAuthorizePath());
+
+    assert.equal(res.statusCode, 303);
+    assert(
+      res.headers.location?.startsWith('/interaction/'),
+      `expected redirect to /interaction/:uid, got ${res.headers.location}`
+    );
+  });
+
+  it('redirects to /interaction/:uid when prompt=login is requested (control)', async function () {
+    const res = await get(buildAuthorizePath({ prompt: 'login' }));
+
+    assert.equal(res.statusCode, 303);
+    assert(
+      res.headers.location?.startsWith('/interaction/'),
+      `expected redirect to /interaction/:uid, got ${res.headers.location}`
+    );
+  });
+});

--- a/test/interaction-policy-test.js
+++ b/test/interaction-policy-test.js
@@ -17,9 +17,24 @@ describe('interaction-policy', function () {
     assert.equal(confirmLoginPrompt.requestable, true, 'should be requestable');
   });
 
-  it('should not have consent prompt (removed)', function () {
+  it('should keep consent prompt registered with a no-op check', function () {
     const consentPrompt = policy.get('consent');
-    assert.equal(consentPrompt, undefined, 'consent prompt should be removed');
+    assert(consentPrompt, 'consent prompt should remain registered');
+    assert.equal(
+      consentPrompt.requestable,
+      true,
+      'consent must be requestable so prompt=consent is accepted by oidc-provider'
+    );
+
+    const upstreamCheck = consentPrompt.checks.find(
+      (c) => c.reason === 'consent_granted_upstream'
+    );
+    assert(upstreamCheck, 'should have consent_granted_upstream check');
+    assert.equal(
+      upstreamCheck.check({}),
+      interactionPolicy.Check.NO_NEED_TO_PROMPT,
+      'consent_granted_upstream should never request a consent prompt'
+    );
   });
 
   describe('is_login_confirmed check', function () {


### PR DESCRIPTION
<!--
When creating a PR, be sure to prepend the PR title with the Conventional Commit type (`feat`, `fix`, or `chore`). This is how we manage package versioning and generating CHANGELOG notes.

Examples:
- "feat: add growl notification to spaces:wait"
- "fix: handle special characters in app names"
- "chore: add dist directory to .gitignore"

The expected Conventional Commit types are listed below.

Learn more about [Conventional Commits](https://www.conventionalcommits.org/).
-->

## Summary
<!-- Brief description of the changes in this PR. -->

Claude Desktop's MCP Custom Connector flow appends `prompt=consent` to the OAuth authorization request when connecting to https://mcp.heroku.com/mcp. The Heroku MCP auth proxy (`heroku/mcp-remote-auth-proxy`) rejects this parameter, returning `invalid_request` with description `unsupported prompt value requested` before the user ever reaches a Heroku login or authorization screen.

Other MCP clients (e.g., VS Code) authenticate against the same endpoint successfully because they do not append prompt=consent.

This PR introduces a more standards-compliant approach that allows clients like Claude Desktop to auth with `prompt=consent`, and allows tools like VS Code to continue operating without `prompt=consent` by not prompting if the client has already authed upstream.

## Type of Change
### Breaking Changes (major semver update)
- [ ] Add a `!` after your change type to denote a change that breaks current behavior

### Feature Additions (minor semver update)
- [ ] **feat**: Introduces a new feature to the codebase

### Patch Updates (patch semver update)
- [x] **fix**: Bug fix
- [ ] **perf**: Performance improvement
- [ ] **deps**: Dependency upgrade
- [ ] **revert**: Revert a previous commit
- [ ] **docs**: Documentation change
- [ ] **style**: Styling update
- [ ] **chore**: Change that does not affect production code
- [ ] **refactor**: Refactoring existing code without changing behavior
- [ ] **tests**: Add/update/remove tests
- [ ] **build**: Change to the build system
- [ ] **ci**: Continuous integration workflow update

## Testing
- Passing CI suffices

## Related Issues
GUS work item: [W-22934093](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002bxm8qYAA/view)